### PR TITLE
Temporary go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module golang.org/x/crypto
+module github.com/skinowski/crypto
 
 go 1.17
 


### PR DESCRIPTION
Using correct module name makes the fork usable
as a go module.